### PR TITLE
Allow configuring baseURL for OpenAI

### DIFF
--- a/llm/openai.go
+++ b/llm/openai.go
@@ -21,6 +21,13 @@ func NewOpenAILLM(apiKey string) *OpenAILLM {
 	return &OpenAILLM{client: client}
 }
 
+func NewOpenAILLMWithHost(apiKey string, host string) *OpenAILLM {
+	config := openai.DefaultConfig(apiKey)
+	config.BaseURL = host
+	openAIClient := openai.NewClientWithConfig(config)
+	return &OpenAILLM{client: openAIClient}
+}
+
 // convertToOpenAIMessages converts our generic Message type to OpenAI's message type
 func convertToOpenAIMessages(messages []Message) []openai.ChatCompletionMessage {
 	openAIMessages := make([]openai.ChatCompletionMessage, len(messages))

--- a/swarm.go
+++ b/swarm.go
@@ -57,6 +57,16 @@ func NewSwarm(apiKey string, provider llm.LLMProvider) *Swarm {
 	return nil
 }
 
+func NewSwarmWithHost(apiKey, host string, provider llm.LLMProvider) *Swarm {
+	if provider == llm.OpenAI {
+		client := llm.NewOpenAILLMWithHost(apiKey, host)
+		return &Swarm{
+			client: client,
+		}
+	}
+	return nil
+}
+
 // getChatCompletion requests a chat completion from the LLM
 func (s *Swarm) getChatCompletion(
 	ctx context.Context,
@@ -251,7 +261,7 @@ func (s *Swarm) Run(
 			toolResults = append(toolResults, ToolResult{
 				ToolName: toolCall.Function.Name,
 				Args:     args,
-				Result:   Result{
+				Result: Result{
 					Success: true,
 					Data:    toolResp.Messages[0].Content,
 					Error:   nil,
@@ -298,7 +308,7 @@ func (s *Swarm) Run(
 	} else {
 		// Add the assistant's message to history
 		history = append(history, choice.Message)
-		
+
 		// Return final response only if there are no tool calls
 		finalResponse := Response{
 			Messages:         history[initLen:],

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -44,6 +44,15 @@ func TestNewSwarm(t *testing.T) {
 	assert.NotNil(t, sw.client)
 }
 
+// TestNewSwarmWithHost tests the NewSwarmWithHost function
+func TestNewSwarmWithHost(t *testing.T) {
+	apiKey := "test-api-key"
+	host := "https://api.xxxxx.com"
+	sw := NewSwarmWithHost(apiKey, host, llm.OpenAI)
+	assert.NotNil(t, sw)
+	assert.NotNil(t, sw.client)
+}
+
 // TestFunctionToDefinition tests the FunctionToDefinition function
 func TestFunctionToDefinition(t *testing.T) {
 	af := AgentFunction{


### PR DESCRIPTION
There are many services which offers the same api than OpenAI for compatibility. Grok for example, also Ollama provides a OpenAI compatible endpoint too, and there are more.

With this change, you can specify the OpenAI BaseURL.