### PR TITLE
add NewSwarmWithCustomProvider

### DIFF
--- a/examples/customproivder/main.go
+++ b/examples/customproivder/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	dotenv "github.com/joho/godotenv"
+	swarmgo "github.com/prathyushnallamothu/swarmgo"
+	"github.com/prathyushnallamothu/swarmgo/llm"
+)
+
+func main() {
+	dotenv.Load()
+
+	aiProvider := llm.NewOpenAILLM(os.Getenv("OPENAI_API_KEY"))
+
+	client := swarmgo.NewSwarmWithCustomProvider(aiProvider, &swarmgo.Config{})
+
+	agent := &swarmgo.Agent{
+		Name:         "Agent",
+		Instructions: "You are a helpful agent.",
+		Model:        "gpt-3.5-turbo",
+	}
+
+	messages := []llm.Message{
+		{Role: llm.RoleUser, Content: "Hi!"},
+	}
+
+	ctx := context.Background()
+	response, err := client.Run(ctx, agent, messages, nil, "", false, false, 5, true)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(response.Messages[len(response.Messages)-1].Content)
+}

--- a/swarm.go
+++ b/swarm.go
@@ -176,6 +176,15 @@ func NewSwarmWithHost(apiKey, host string, provider llm.LLMProvider) *Swarm {
 	return NewSwarm(apiKey, provider)
 }
 
+// NewSwarmWithCustomProvider creates a Swarm with a custom LLM provider implementation
+func NewSwarmWithCustomProvider(providerImpl llm.LLM, config *Config) *Swarm {
+	return &Swarm{
+		client:      providerImpl,
+		initialized: true,
+		config:      config,
+	}
+}
+
 // SetTokenCounter sets a function to count tokens in messages
 func (s *Swarm) SetTokenCounter(counter func(string) int) {
 	s.tokenCounter = counter

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -53,6 +53,12 @@ func TestNewSwarmWithHost(t *testing.T) {
 	assert.NotNil(t, sw.client)
 }
 
+func TestNewSwarmWithCustomProvider(t *testing.T) {
+	sw := NewSwarmWithCustomProvider(&MockLLM{}, &Config{})
+	assert.NotNil(t, sw)
+	assert.NotNil(t, sw.client)
+}
+
 // TestFunctionToDefinition tests the FunctionToDefinition function
 func TestFunctionToDefinition(t *testing.T) {
 	af := AgentFunction{


### PR DESCRIPTION
## Overview
This Pull Request introduces the ability to use SwarmGo with a custom provider implementation that cannot be contributed directly to this repository.

##  Motivation
By allowing users to pass a custom provider implementation during swarm creation, developers can leverage the llm.LLM interface with their own providers. This enhancement opens up greater flexibility for integrating with proprietary or specialized LLM providers.

##  Changes Made
- Added a new constructor to facilitate the creation of a Swarm instance using a custom llm.LLM provider implementation.

## Benefits
- **Flexibility**: Users can now easily integrate custom LLM implementations without the need for direct contributions to the main repository.
- **Extensibility**: This change enhances the adaptability of SwarmGo to various use cases and environments.

@prathyushnallamothu 

